### PR TITLE
[PERF ]: 상점 상세 조회 Redis 캐시 도입 및 직렬화 설정 개선

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,13 @@ dependencies {
     //flywaydb
     implementation "org.flywaydb:flyway-core"
     implementation "org.flywaydb:flyway-database-postgresql"
+
+    //redis
+    implementation "org.springframework.boot:spring-boot-starter-data-redis"
+    implementation "org.springframework.boot:spring-boot-starter-cache"
+
+    implementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/test/buymebackend/config/cache/CacheConfig.java
+++ b/src/main/java/com/test/buymebackend/config/cache/CacheConfig.java
@@ -1,0 +1,55 @@
+package com.test.buymebackend.config.cache;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+
+    @Bean
+    public CacheManager cacheManager(RedisConnectionFactory cf) {
+        ObjectMapper redisMapper = new ObjectMapper()
+                .registerModule(new JavaTimeModule())
+                .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .activateDefaultTyping(
+                        LaissezFaireSubTypeValidator.instance,
+                        ObjectMapper.DefaultTyping.NON_FINAL,
+                        JsonTypeInfo.As.PROPERTY
+                );
+
+        var keySer   = new StringRedisSerializer();
+        var valueSer = new GenericJackson2JsonRedisSerializer(redisMapper);
+
+        var defaultCfg = RedisCacheConfiguration.defaultCacheConfig()
+                .entryTtl(Duration.ofMinutes(10))
+                .disableCachingNullValues()
+                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(keySer))
+                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(valueSer));
+
+        return RedisCacheManager.builder(cf)
+                .cacheDefaults(defaultCfg)
+                .withCacheConfiguration("store:detail", defaultCfg.entryTtl(Duration.ofMinutes(5)))
+                .withCacheConfiguration("store:list",   defaultCfg.entryTtl(Duration.ofMinutes(2)))
+                .withCacheConfiguration("store:menus",  defaultCfg.entryTtl(Duration.ofMinutes(20)))
+                .build();
+    }
+}
+


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
<!---- Resolves: #(Issue Number) -->
- @Cacheable("store:detail")/@Cacheable("store:list") 적용 (키: storeId, "<page>:<category|ALL>")
- 조회 메서드에 @Transactional(readOnly = true) 적용
- 캐시 무효화 정밀화: 생성 시 store:list 전체, 수정 시 store:list 전체 + store:detail/store:menus는 해당 storeId만
- Jackson 직렬화 설정 보강(JavaTime, 타입정보 포함, unknown 무시)

왜: 조회 레이턴시 단축·DB 부하 절감 및 캐시 스키마 변경 내성 확보
Resolves: #19 



### 재현 방법(Repro)
```
# 토큰/URL 준비
URL='http://localhost:8080/stores/1'
TOKEN='<JWT>'

# MISS → HIT 비교
curl -s -o /dev/null -w '1st: %{time_total}s\n' "$URL" -H "Authorization: Bearer $TOKEN"
curl -s -o /dev/null -w '2nd: %{time_total}s\n' "$URL" -H "Authorization: Bearer $TOKEN"

# Redis 확인(개발)
redis-cli KEYS "store:*"
redis-cli TTL "store:detail::1"

# 초기화(개발만)
# redis-cli FLUSHDB
```


### 성능 검증(Results)

- 동일 요청 2회 연속 호출 (로컬):
  - 1회차(MISS): ~0.22s
  - 2회차(HIT): ~0.02s

- 서버 로그: 첫 호출에만
 `INFO ... StoreService : [TEST] DB HIT - getStoreDetail(1)`
 
 
<img width="856" height="218" alt="스크린샷 2025-09-28 오전 6 28 20" src="https://github.com/user-attachments/assets/1302f861-13c5-41e1-b4fe-b6188d432573" />

<img width="1105" height="22" alt="스크린샷 2025-09-28 오전 6 28 29" src="https://github.com/user-attachments/assets/77168939-c00e-4657-af7a-bb9fed1512dc" />

<img width="790" height="125" alt="스크린샷 2025-09-28 오전 6 28 39" src="https://github.com/user-attachments/assets/718edb24-4f01-41d1-afaf-948c3e196496" />

 
 

체크리스트(Checklist)
## PR 유형
어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.)
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트)
